### PR TITLE
Add contributing.md file

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,8 @@
+# Contributing
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
+3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
+4. Push to the branch (`git push origin feature/AmazingFeature`)
+5. Open a Pull Request

--- a/README.md
+++ b/README.md
@@ -132,10 +132,4 @@ CloudFormation_To_Terraform/
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
+Please see [contributing.md](.github/contributing.md)


### PR DESCRIPTION
## Rationale
It's great that you included contribution instructions in your readme. the `contributing.md` file is a github specific file, which will include your instructions anytime someone wants to submit a patch. For example, on this pull request page. You can read more about it here: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors

You can set this file up in three places:
- at the root
- in the `docs` folder
- in the `.github` folder

this is all a matter of personal preference. My preference is the `.github` folder, since that lets me keep all my github specific metadata in one place-- for example, if it later wanted to add github actions.